### PR TITLE
feat(CSR-812): add new color with dark mode version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@timechimp/tacugama",
-  "version": "0.24.4",
+  "version": "0.24.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@timechimp/tacugama",
-      "version": "0.24.4",
+      "version": "0.24.6",
       "license": "MIT",
       "dependencies": {
         "@ag-grid-community/core": "~25.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.24.5",
+  "version": "0.24.6",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -5,11 +5,11 @@ import {
   createThemedWithStyle,
   createThemedUseStyletron,
 } from 'baseui';
-import { CustomThemeType, CustomOverrideType } from 'models';
+import { CustomThemeType, CustomOverrideType, CustomColors } from 'models';
 
 import { default as basePrimitives } from './primitives';
 import { default as baseOverrides } from './overrides';
-import { lightColors, darkColors } from './colors';
+import { lightColors, darkColors, customColors } from './colors';
 import { lightBorders, darkBorders } from './borders';
 import { lightLighting, darkLighting } from './lighting';
 
@@ -62,6 +62,11 @@ export const getTheme = (options: ThemeOptionsProps = defaultTheme): Theme => {
     primary700: `rgba(${primaryRgb.r}, ${primaryRgb.g}, ${primaryRgb.b}, .7)`, // TODO make rgb darker?
   };
 
+  const darkCustomColors: CustomColors = {
+    ...customColors,
+    primarySubtle: '#141414',
+  };
+
   const lightOverrides: CustomOverrideType = {
     ...baseOverrides,
     colors: lightColors,
@@ -74,6 +79,7 @@ export const getTheme = (options: ThemeOptionsProps = defaultTheme): Theme => {
 
   const darkOverrides: CustomOverrideType = {
     ...baseOverrides,
+    customColors: darkCustomColors,
     colors: darkColors,
     borders: darkBorders,
     lighting: darkLighting,


### PR DESCRIPTION
In the task https://timechimp.atlassian.net/browse/CSR-812, when I change the color of the workspace toggler to another (not custom), the color was displayed normally in dark mode. As I understand that custom colors have not alternatives in dark mode. I tried to add it.