### PR TITLE
Revert "chore(deps): bump styletron-engine-atomic from 1.4.8 to 1.5.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "react-color": "^2.19.3",
         "react-hook-form": "^7.41.0",
         "react-number-format": "^4.7.3",
-        "styletron-engine-atomic": "^1.5.0",
+        "styletron-engine-atomic": "^1.4.7",
         "styletron-react": "^6.1.0",
         "victory": "^36.0.1"
       },
@@ -31365,12 +31365,12 @@
       }
     },
     "node_modules/styletron-engine-atomic": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/styletron-engine-atomic/-/styletron-engine-atomic-1.5.0.tgz",
-      "integrity": "sha512-5rR6cbWqeKlrFUtIyw7aBe3Zn5XDCmxLJ6q7MAYwBCk6pbdBfj5MtoedH6KBygwjTNp7uddE536YrLvLP0N8/w==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/styletron-engine-atomic/-/styletron-engine-atomic-1.4.8.tgz",
+      "integrity": "sha512-KLyDkigcIrIMzUlX0usBfO/BBwnh1yC/48+DqP4LSZn8UgGP00oStxoezAH8pYhal1amvBJ7tLVs7tNZDUTAdg==",
       "dependencies": {
         "inline-style-prefixer": "^5.1.0",
-        "styletron-standard": "^3.1.0"
+        "styletron-standard": "^3.0.5"
       }
     },
     "node_modules/styletron-react": {
@@ -59423,12 +59423,12 @@
       }
     },
     "styletron-engine-atomic": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/styletron-engine-atomic/-/styletron-engine-atomic-1.5.0.tgz",
-      "integrity": "sha512-5rR6cbWqeKlrFUtIyw7aBe3Zn5XDCmxLJ6q7MAYwBCk6pbdBfj5MtoedH6KBygwjTNp7uddE536YrLvLP0N8/w==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/styletron-engine-atomic/-/styletron-engine-atomic-1.4.8.tgz",
+      "integrity": "sha512-KLyDkigcIrIMzUlX0usBfO/BBwnh1yC/48+DqP4LSZn8UgGP00oStxoezAH8pYhal1amvBJ7tLVs7tNZDUTAdg==",
       "requires": {
         "inline-style-prefixer": "^5.1.0",
-        "styletron-standard": "^3.1.0"
+        "styletron-standard": "^3.0.5"
       }
     },
     "styletron-react": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "react-color": "^2.19.3",
     "react-hook-form": "^7.41.0",
     "react-number-format": "^4.7.3",
-    "styletron-engine-atomic": "^1.5.0",
+    "styletron-engine-atomic": "^1.4.7",
     "styletron-react": "^6.1.0",
     "victory": "^36.0.1"
   },


### PR DESCRIPTION
Reverts TimeChimp/tacugama#920