### PR TITLE
[CSR-4652] Disable submit onclick edit (BREAKING CHANGE)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,12 @@
 {
   "name": "@timechimp/tacugama",
-<<<<<<< HEAD
   "version": "11.0.0",
-=======
-  "version": "10.2.2",
->>>>>>> f7732d5937cc9e4044e083c456c610233e556be6
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@timechimp/tacugama",
-<<<<<<< HEAD
       "version": "11.0.0",
-=======
-      "version": "10.2.1",
->>>>>>> f7732d5937cc9e4044e083c456c610233e556be6
       "license": "MIT",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "25.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "10.1.2",
+  "version": "11.0.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/edit-page/EditPage.stories.tsx
+++ b/src/components/edit-page/EditPage.stories.tsx
@@ -25,13 +25,11 @@ const Template: Story<EditPageProps> = () => {
 
   return (
     <EditPage
-      entity="team"
       sideNavItems={getSideNavItems()}
       title="Edit Page"
       returnToTitle={'Page'}
       onCancel={() => console.log('Cancel')}
       loading={false}
-      onSave={async () => console.log('Save')}
       cancelText={'Cancel'}
       saveText={'Save'}
       backText={'Back'}

--- a/src/components/edit-page/EditPage.tsx
+++ b/src/components/edit-page/EditPage.tsx
@@ -25,11 +25,9 @@ export const EditPage = ({
   backText,
   cancelText,
   onCancel,
-  onSave,
 }: EditPageProps) => {
   const [tab, setTab] = useState<string>(sideNavItems[0]?.id);
   const [secondaryTab, setSecondaryTab] = useState<string>();
-  const [isSaving, setIsSaving] = useState(false);
 
   const {
     theme: {
@@ -90,14 +88,6 @@ export const EditPage = ({
     setTab(parentId);
   };
 
-  const onSaveClick = async () => {
-    if (onSave) {
-      setIsSaving(true);
-      await onSave();
-      setIsSaving(false);
-    }
-  };
-
   const onCancelClick = () => {
     if (onCancel) {
       onCancel();
@@ -115,7 +105,7 @@ export const EditPage = ({
           {title}
         </HeadingSmall>
         <ButtonBox>
-          {onSave ? (
+          {saveText ? (
             <>
               <Button
                 kind={ButtonKind.secondary}
@@ -125,13 +115,7 @@ export const EditPage = ({
               >
                 {cancelText}
               </Button>
-              <Button
-                isLoading={isSaving || updating}
-                onClick={onSaveClick}
-                testId={`save-button-${entity}`}
-                disabled={isSaveDisabled}
-                type="submit"
-              >
+              <Button isLoading={updating} testId={`save-button-${entity}`} disabled={isSaveDisabled} type="submit">
                 {saveText}
               </Button>
             </>

--- a/src/components/edit-page/EditPage.tsx
+++ b/src/components/edit-page/EditPage.tsx
@@ -107,26 +107,15 @@ export const EditPage = ({
         <ButtonBox>
           {saveText ? (
             <>
-              <Button
-                kind={ButtonKind.secondary}
-                onClick={onCancelClick}
-                testId={`cancel-button-${entity}`}
-                type="button"
-              >
+              <Button kind={ButtonKind.secondary} onClick={onCancelClick}>
                 {cancelText}
               </Button>
-              <Button isLoading={updating} testId={`save-button-${entity}`} disabled={isSaveDisabled} type="submit">
+              <Button isLoading={updating} disabled={isSaveDisabled} type="submit">
                 {saveText}
               </Button>
             </>
           ) : (
-            <Button
-              kind={ButtonKind.secondary}
-              onClick={onCancelClick}
-              testId={`cancel-button-${entity}`}
-              type="button"
-              startEnhancer={<CaretLeftIcon />}
-            >
+            <Button kind={ButtonKind.secondary} onClick={onCancelClick} startEnhancer={<CaretLeftIcon />}>
               {backText}
             </Button>
           )}

--- a/src/components/edit-page/EditPage.tsx
+++ b/src/components/edit-page/EditPage.tsx
@@ -15,7 +15,6 @@ import { Box } from '../box';
 export const EditPage = ({
   sideNavItems,
   title,
-  entity,
   selectedTab,
   selectedSubTab,
   loading,

--- a/src/components/edit-page/EditPageContainer.tsx
+++ b/src/components/edit-page/EditPageContainer.tsx
@@ -10,7 +10,6 @@ import { padding } from '../../utils';
 import { Separator } from '../separator';
 import { AddLineIcon } from '../icons';
 
-const SMALL_CONTAINER_MAX_WIDTH = '700px';
 const BOX_HEIGHT = '90vh';
 const TOP_BOTTOM_PADDING = 50;
 const TOTAL_PADDING = TOP_BOTTOM_PADDING * 2;
@@ -18,22 +17,11 @@ const SMALL_CONTAINER_HEIGHT = `calc(${BOX_HEIGHT} - ${TOTAL_PADDING}px)`;
 
 export const EditPageContainer = ({
   title,
-  fullWidth = true,
-  width = 'auto',
   children,
-  justifyContent = 'center',
   headerButtonTitle,
   onHeaderButtonClick,
-  footerButtonTitle,
-  footerButtonIsLoading,
-  footerButtonType = 'button',
-  onFooterButtonClick,
-  isFooterButton = true,
-  justifyFooterButtons = 'flex-end',
-  secondaryFooterButtonTitle,
-  secondaryFooterButtonProps = {},
-  paddingLeftRight,
-  routerPrompt,
+  submitButtonText,
+  updating = false,
 }: EditPageContainerProps) => {
   const {
     theme: {
@@ -60,41 +48,28 @@ export const EditPageContainer = ({
       </Block>
       <Separator noMargin />
       <Block
-        {...padding(scale800, paddingLeftRight ?? scale1600)}
+        {...padding(scale800, scale1600)}
         display="flex"
-        justifyContent={justifyContent}
+        justifyContent="center"
         overflow="auto"
         height={SMALL_CONTAINER_HEIGHT}
       >
-        <Block maxWidth={!fullWidth ? SMALL_CONTAINER_MAX_WIDTH : undefined} width={fullWidth ? '100%' : width}>
-          {children}
-        </Block>
+        <Block width="100%">{children}</Block>
       </Block>
       <Separator noMargin />
       <Block
         display="flex"
         {...padding(scale200, scale1600)}
         height={scale1200}
-        justifyContent={justifyFooterButtons}
+        justifyContent="flex-end"
         alignItems="center"
       >
-        {secondaryFooterButtonTitle ? (
-          <Button {...secondaryFooterButtonProps} kind={ButtonKind.secondary}>
-            {secondaryFooterButtonTitle}
-          </Button>
-        ) : null}
-        {footerButtonTitle && isFooterButton ? (
-          <Button
-            type={footerButtonType}
-            kind={ButtonKind.primary}
-            onClick={onFooterButtonClick}
-            isLoading={footerButtonIsLoading}
-          >
-            {footerButtonTitle}
+        {submitButtonText ? (
+          <Button type="submit" kind={ButtonKind.primary} isLoading={updating}>
+            {submitButtonText}
           </Button>
         ) : null}
       </Block>
-      {onFooterButtonClick && routerPrompt}
     </Box>
   );
 };

--- a/src/components/edit-page/types.ts
+++ b/src/components/edit-page/types.ts
@@ -9,7 +9,6 @@ export interface EditPageSkeletonProps {
 export interface EditPageProps {
   loading?: boolean;
   updating?: boolean;
-  entity: string;
   title: string | undefined;
   selectedTab?: string;
   selectedSubTab?: string;

--- a/src/components/edit-page/types.ts
+++ b/src/components/edit-page/types.ts
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 import { SideNavItem } from 'components/side-nav';
 import { UseFormReset } from 'react-hook-form';
-import { ButtonProps } from '../button';
 
 export interface EditPageSkeletonProps {
   numberOfSideNavItems?: number;
@@ -17,10 +16,9 @@ export interface EditPageProps {
   returnToTitle?: string | null;
   sideNavItems: SideNavItem[];
   onCancel?: () => void;
-  onSave?: () => Promise<void>;
   isSaveDisabled?: boolean;
   cancelText: string;
-  saveText: string;
+  saveText?: string;
   backText: string;
 }
 
@@ -31,20 +29,9 @@ export interface RouterPromptProps {
 
 export interface EditPageContainerProps {
   title: string;
-  fullWidth?: boolean;
-  width?: string;
   children: ReactNode;
-  justifyContent?: 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'space-evenly';
   headerButtonTitle?: string;
   onHeaderButtonClick?: () => void;
-  footerButtonTitle?: string;
-  footerButtonIsLoading?: boolean;
-  footerButtonType?: 'button' | 'submit' | 'reset';
-  onFooterButtonClick?: () => Promise<void>;
-  isFooterButton?: boolean;
-  justifyFooterButtons?: 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'space-evenly';
-  secondaryFooterButtonTitle?: string;
-  secondaryFooterButtonProps?: ButtonProps;
-  paddingLeftRight?: string;
-  routerPrompt?: JSX.Element;
+  submitButtonText?: string;
+  updating?: boolean;
 }


### PR DESCRIPTION
Removes (mostly) unused props and always forces the save button to be a submit button. 
Saving should be handled by the form onsubmit. 
