### PR TITLE
[CSR-4692] (BREAKING CHANGE) Alignment basic table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@timechimp/tacugama",
-  "version": "11.2.1",
+  "version": "12.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@timechimp/tacugama",
-      "version": "11.2.1",
+      "version": "12.0.0",
       "license": "MIT",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "25.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@timechimp/tacugama",
-  "version": "11.2.0",
+  "version": "11.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@timechimp/tacugama",
-      "version": "11.2.0",
+      "version": "11.2.1",
       "license": "MIT",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "25.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "11.2.1",
+  "version": "12.0.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "11.2.0",
+  "version": "11.2.1",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/basic-table/BasicTable.tsx
+++ b/src/components/basic-table/BasicTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BasicTableProps, BasicTableRow } from './types';
+import { BasicTableProps, BasicTableRow, BasicTableColumnType } from './types';
 import { useTheme } from '../../providers';
 import { padding, border } from '../../utils';
 import { TableBuilder, TableBuilderColumn, StyledTableHeadCell, StyledTableEmptyMessage } from 'baseui/table-semantic';
@@ -93,7 +93,11 @@ export const BasicTable = ({ columns, emptyMessage, ...props }: BasicTableProps)
               },
               component: ({ $style, children }) => (
                 <StyledTableHeadCell style={$style}>
-                  <FlexItem justifyContent={column?.alignEnd ? 'flex-end' : 'flex-start'}>{children}</FlexItem>
+                  <FlexItem
+                    justifyContent={column?.type === BasicTableColumnType.Financial ? 'flex-end' : 'flex-start'}
+                  >
+                    {children}
+                  </FlexItem>
                 </StyledTableHeadCell>
               ),
             },

--- a/src/components/basic-table/Cell.tsx
+++ b/src/components/basic-table/Cell.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { BasicTableColumn, BasicTableColumnType, BasicTableRow } from './types';
 import { ParagraphSmall } from '../typography';
 import { FlexItem } from '../flex-item';
+import { Align } from '../input/types';
 
-const CellWrapper = ({ children, alignEnd }: { children: React.ReactNode; alignEnd?: boolean }) => (
-  <FlexItem height="100%" justifyContent={alignEnd ? 'flex-end' : 'flex-start'} alignItems="center">
+const CellWrapper = ({ children, alignRight }: { children: React.ReactElement; alignRight?: boolean }) => (
+  <FlexItem height="100%" justifyContent={alignRight ? 'flex-end' : 'flex-start'} alignItems="center">
     {children}
   </FlexItem>
 );
@@ -15,11 +16,22 @@ export const renderCell = (row: BasicTableRow, column: BasicTableColumn) => {
 
   const map = {
     [BasicTableColumnType.Text]: () => (
-      <CellWrapper alignEnd={column?.alignEnd}>
+      <CellWrapper>
         <ParagraphSmall>{value}</ParagraphSmall>
       </CellWrapper>
     ),
-    [BasicTableColumnType.Custom]: () => <CellWrapper alignEnd={column?.alignEnd}>{value}</CellWrapper>,
+    [BasicTableColumnType.Custom]: () => <CellWrapper>{value}</CellWrapper>,
+    [BasicTableColumnType.Financial]: () => (
+      <CellWrapper alignRight>
+        <>
+          {typeof value !== 'string'
+            ? React.cloneElement(value, {
+                align: Align.right,
+              })
+            : value}
+        </>
+      </CellWrapper>
+    ),
   };
 
   return map[type ?? BasicTableColumnType.Text]();

--- a/src/components/basic-table/Cell.tsx
+++ b/src/components/basic-table/Cell.tsx
@@ -20,15 +20,21 @@ export const renderCell = (row: BasicTableRow, column: BasicTableColumn) => {
         <ParagraphSmall>{value}</ParagraphSmall>
       </CellWrapper>
     ),
-    [BasicTableColumnType.Custom]: () => <CellWrapper>{value}</CellWrapper>,
+    [BasicTableColumnType.Custom]: () => (
+      <CellWrapper>
+        <>{value}</>
+      </CellWrapper>
+    ),
     [BasicTableColumnType.Financial]: () => (
       <CellWrapper alignRight>
         <>
-          {typeof value !== 'string'
-            ? React.cloneElement(value, {
-                align: Align.right,
-              })
-            : value}
+          {value && typeof value !== 'string' && typeof value !== 'number' ? (
+            React.cloneElement(value, {
+              align: Align.right,
+            })
+          ) : (
+            <ParagraphSmall>{value}</ParagraphSmall>
+          )}
         </>
       </CellWrapper>
     ),

--- a/src/components/basic-table/__tests__/constants.tsx
+++ b/src/components/basic-table/__tests__/constants.tsx
@@ -2,10 +2,11 @@ import { Button } from '../../button';
 import { Checkbox } from '../../checkbox';
 import { Toggle, ToggleSize } from '../../toggle';
 import { Input } from '../../input';
+import { PriceInput } from '../../input/price-input';
 import React from 'react';
-import { BasicTableColumnType, BasicTableRow } from '../types';
+import { BasicTableColumnType, BasicTableRow, BasicTableColumn } from '../types';
 
-export const COLUMNS = [
+export const COLUMNS: BasicTableColumn[] = [
   {
     label: 'Name',
     field: 'name',
@@ -18,7 +19,7 @@ export const COLUMNS = [
     label: 'Price',
     type: BasicTableColumnType.Financial,
     field: 'price',
-    width: '50px',
+    width: '200px',
   },
   {
     label: 'Actions',
@@ -36,19 +37,25 @@ export const DATA: BasicTableRow[] = [
   },
   {
     name: 'Sarah Brown',
-    price: '$31',
+    price: '',
     address: '100 Broadway St., New York City, New York',
     actions: <Input placeholder="Fill me in" />,
   },
   {
     name: 'Jane Doe',
-    price: '$32',
+    price: (
+      <PriceInput
+        onChange={(e) => {
+          console.log(e);
+        }}
+      />
+    ),
     address: '100 Main St., Los Angeles, California',
     actions: <Toggle size={ToggleSize.large} />,
   },
   {
     name: 'Hank Smith',
-    price: '$40',
+    price: 40,
     address: '100 Baker St., Dallas, Texas',
     actions: <Checkbox />,
   },

--- a/src/components/basic-table/__tests__/constants.tsx
+++ b/src/components/basic-table/__tests__/constants.tsx
@@ -11,16 +11,10 @@ export const COLUMNS = [
     field: 'name',
   },
   {
-    label: 'Address',
-    type: BasicTableColumnType.Text,
-    field: 'address',
-  },
-  {
     label: 'Price',
     type: BasicTableColumnType.Financial,
     field: 'price',
     width: '50px',
-    alignEnd: true,
   },
   {
     label: 'Actions',

--- a/src/components/basic-table/__tests__/constants.tsx
+++ b/src/components/basic-table/__tests__/constants.tsx
@@ -3,7 +3,7 @@ import { Checkbox } from '../../checkbox';
 import { Toggle, ToggleSize } from '../../toggle';
 import { Input } from '../../input';
 import React from 'react';
-import { BasicTableColumnType } from '../types';
+import { BasicTableColumnType, BasicTableRow } from '../types';
 
 export const COLUMNS = [
   {
@@ -11,16 +11,16 @@ export const COLUMNS = [
     field: 'name',
   },
   {
-    label: 'Age',
-    type: BasicTableColumnType.Text,
-    field: 'age',
-    width: '50px',
-    alignEnd: true,
-  },
-  {
     label: 'Address',
     type: BasicTableColumnType.Text,
     field: 'address',
+  },
+  {
+    label: 'Price',
+    type: BasicTableColumnType.Financial,
+    field: 'price',
+    width: '50px',
+    alignEnd: true,
   },
   {
     label: 'Actions',
@@ -29,28 +29,28 @@ export const COLUMNS = [
   },
 ];
 
-export const DATA = [
+export const DATA: BasicTableRow[] = [
   {
     name: 'John Smith',
-    age: 30,
-    address: '100 Market St., San Francisco, California',
+    price: '$30',
+    address: <p>'100 Market St., San Francisco, California'</p>,
     actions: <Button onClick={() => alert('Hey there!')}>Action!</Button>,
   },
   {
     name: 'Sarah Brown',
-    age: 31,
+    price: '$31',
     address: '100 Broadway St., New York City, New York',
     actions: <Input placeholder="Fill me in" />,
   },
   {
     name: 'Jane Doe',
-    age: 32,
+    price: '$32',
     address: '100 Main St., Los Angeles, California',
     actions: <Toggle size={ToggleSize.large} />,
   },
   {
     name: 'Hank Smith',
-    age: 40,
+    price: '$40',
     address: '100 Baker St., Dallas, Texas',
     actions: <Checkbox />,
   },

--- a/src/components/basic-table/__tests__/constants.tsx
+++ b/src/components/basic-table/__tests__/constants.tsx
@@ -11,6 +11,10 @@ export const COLUMNS = [
     field: 'name',
   },
   {
+    label: 'Address',
+    field: 'address',
+  },
+  {
     label: 'Price',
     type: BasicTableColumnType.Financial,
     field: 'price',

--- a/src/components/basic-table/types.ts
+++ b/src/components/basic-table/types.ts
@@ -14,7 +14,7 @@ export interface BasicTableColumn {
 }
 
 export interface BasicTableRow {
-  [field: string]: any;
+  [field: string]: string | number | React.ReactElement;
 }
 
 type OmittedTableProps = 'columns' | 'data';

--- a/src/components/basic-table/types.ts
+++ b/src/components/basic-table/types.ts
@@ -3,6 +3,7 @@ import { TableProps } from 'baseui/table-semantic';
 export enum BasicTableColumnType {
   Text = 'text',
   Custom = 'custom',
+  Financial = 'financial',
 }
 
 export interface BasicTableColumn {
@@ -10,7 +11,6 @@ export interface BasicTableColumn {
   field: string;
   type?: BasicTableColumnType;
   width?: string;
-  alignEnd?: boolean;
 }
 
 export interface BasicTableRow {


### PR DESCRIPTION
Adds an financial column type to basicTable which also adds a align right when a component is being passed ( like inputs ). 
Also added more exact typing so data being passed through data should be more exactly mapped. 
Covered this in next in the following branch: https://github.com/TimeChimp/fe-next/compare/fix/CSR-4902/refactor-basic-table-change 