### PR TITLE
[CSR-4920] Basic table variant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@timechimp/tacugama",
-  "version": "12.0.0",
+  "version": "12.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@timechimp/tacugama",
-      "version": "12.0.0",
+      "version": "12.2.0",
       "license": "MIT",
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "25.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "12.0.1",
+  "version": "12.2.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/components/basic-table/BasicTable.stories.tsx
+++ b/src/components/basic-table/BasicTable.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 
-import { BasicTable } from '.';
+import { BasicTable, SecondaryBasicTable } from '.';
 import { BasicTableProps } from './types';
 import { COLUMNS, DATA } from './__tests__/constants';
 
@@ -29,4 +29,12 @@ EmptyData.args = {
   columns: COLUMNS,
   data: [],
   emptyMessage: 'No items added...',
+};
+
+const TemplateSecondary: Story<BasicTableProps> = (args) => <SecondaryBasicTable {...args} />;
+
+export const Secondary = TemplateSecondary.bind({});
+Secondary.args = {
+  columns: COLUMNS,
+  data: DATA,
 };

--- a/src/components/basic-table/BasicTable.stories.tsx
+++ b/src/components/basic-table/BasicTable.stories.tsx
@@ -38,3 +38,10 @@ Secondary.args = {
   columns: COLUMNS,
   data: DATA,
 };
+
+export const EmptyDataSecondary = TemplateSecondary.bind({});
+EmptyDataSecondary.args = {
+  columns: COLUMNS,
+  data: [],
+  emptyMessage: 'No items added...',
+};

--- a/src/components/basic-table/BasicTable.stories.tsx
+++ b/src/components/basic-table/BasicTable.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
 
-import { BasicTable, SecondaryBasicTable } from '.';
+import { BasicTable, EmbeddedTable } from '.';
 import { BasicTableProps } from './types';
 import { COLUMNS, DATA } from './__tests__/constants';
 
@@ -31,16 +31,16 @@ EmptyData.args = {
   emptyMessage: 'No items added...',
 };
 
-const TemplateSecondary: Story<BasicTableProps> = (args) => <SecondaryBasicTable {...args} />;
+const TemplateEmbeddedTable: Story<BasicTableProps> = (args) => <EmbeddedTable {...args} />;
 
-export const Secondary = TemplateSecondary.bind({});
-Secondary.args = {
+export const Embedded = TemplateEmbeddedTable.bind({});
+Embedded.args = {
   columns: COLUMNS,
   data: DATA,
 };
 
-export const EmptyDataSecondary = TemplateSecondary.bind({});
-EmptyDataSecondary.args = {
+export const EmbeddedEmptyData = TemplateEmbeddedTable.bind({});
+EmbeddedEmptyData.args = {
   columns: COLUMNS,
   data: [],
   emptyMessage: 'No items added...',

--- a/src/components/basic-table/BasicTable.tsx
+++ b/src/components/basic-table/BasicTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { BasicTableProps, BasicTableRow, BasicTableColumnType } from './types';
 import { TableBuilderColumn } from 'baseui/table-semantic';
+import { BasicTableProps, BasicTableRow, BasicTableColumnType } from './types';
 import { renderCell, BasicTableBuilder, BasicTableHeadCell } from './components';
 import { useBasicTableStyles } from './hooks';
 
@@ -8,38 +8,36 @@ export const BasicTable = ({ columns, emptyMessage, ...props }: BasicTableProps)
   const { tableBodyCellStyles, tableHeadCellStyles, getSidePadding } = useBasicTableStyles();
 
   return (
-    <>
-      <BasicTableBuilder emptyMessage={emptyMessage} {...props}>
-        {columns.map((column, index) => (
-          <TableBuilderColumn<BasicTableRow>
-            key={column.field}
-            header={column.label}
-            overrides={{
-              TableHeadCell: {
-                style: {
-                  ...tableHeadCellStyles,
-                  ...getSidePadding(index, columns.length),
-                  width: column.width ?? 'auto',
-                },
-                component: ({ $style, children }) => (
-                  <BasicTableHeadCell style={$style} alignEnd={column?.type === BasicTableColumnType.Financial}>
-                    {children}
-                  </BasicTableHeadCell>
-                ),
+    <BasicTableBuilder emptyMessage={emptyMessage} {...props}>
+      {columns.map((column, index) => (
+        <TableBuilderColumn<BasicTableRow>
+          key={column.field}
+          header={column.label}
+          overrides={{
+            TableHeadCell: {
+              style: {
+                ...tableHeadCellStyles,
+                ...getSidePadding(index, columns.length),
+                width: column.width ?? 'auto',
               },
-              TableBodyCell: {
-                style: {
-                  ...tableBodyCellStyles,
-                  ...getSidePadding(index, columns.length),
-                  width: column.width ?? 'auto',
-                },
+              component: ({ $style, children }) => (
+                <BasicTableHeadCell style={$style} alignEnd={column?.type === BasicTableColumnType.Financial}>
+                  {children}
+                </BasicTableHeadCell>
+              ),
+            },
+            TableBodyCell: {
+              style: {
+                ...tableBodyCellStyles,
+                ...getSidePadding(index, columns.length),
+                width: column.width ?? 'auto',
               },
-            }}
-          >
-            {(row) => renderCell(row, column)}
-          </TableBuilderColumn>
-        ))}
-      </BasicTableBuilder>
-    </>
+            },
+          }}
+        >
+          {(row) => renderCell(row, column)}
+        </TableBuilderColumn>
+      ))}
+    </BasicTableBuilder>
   );
 };

--- a/src/components/basic-table/BasicTable.tsx
+++ b/src/components/basic-table/BasicTable.tsx
@@ -5,12 +5,12 @@ import { renderCell, BasicTableBuilder, BasicTableHeadCell } from './components'
 import { useBasicTableStyles } from './hooks';
 
 export const BasicTable = ({ columns, emptyMessage, ...props }: BasicTableProps) => {
-  const { tableBodyCellStyles, tableHeadCellStyles } = useBasicTableStyles();
+  const { tableBodyCellStyles, tableHeadCellStyles, getSidePadding } = useBasicTableStyles();
 
   return (
     <>
       <BasicTableBuilder emptyMessage={emptyMessage} {...props}>
-        {columns.map((column) => (
+        {columns.map((column, index) => (
           <TableBuilderColumn<BasicTableRow>
             key={column.field}
             header={column.label}
@@ -18,6 +18,7 @@ export const BasicTable = ({ columns, emptyMessage, ...props }: BasicTableProps)
               TableHeadCell: {
                 style: {
                   ...tableHeadCellStyles,
+                  ...getSidePadding(index, columns.length),
                   width: column.width ?? 'auto',
                 },
                 component: ({ $style, children }) => (
@@ -29,6 +30,7 @@ export const BasicTable = ({ columns, emptyMessage, ...props }: BasicTableProps)
               TableBodyCell: {
                 style: {
                   ...tableBodyCellStyles,
+                  ...getSidePadding(index, columns.length),
                   width: column.width ?? 'auto',
                 },
               },

--- a/src/components/basic-table/EmbeddedTable.tsx
+++ b/src/components/basic-table/EmbeddedTable.tsx
@@ -4,12 +4,12 @@ import { BasicTableProps, BasicTableRow, BasicTableColumnType } from './types';
 import { renderCell, BasicTableBuilder, BasicTableHeadCell } from './components';
 import { useBasicTableStyles } from './hooks';
 
-export const SecondaryBasicTable = ({ columns, emptyMessage, ...props }: BasicTableProps) => {
+export const EmbeddedTable = ({ columns, emptyMessage, ...props }: BasicTableProps) => {
   const { tableBodyCellStyles, tableHeadCellStyles, getSidePadding } = useBasicTableStyles();
 
   return (
     <>
-      <BasicTableBuilder emptyMessage={emptyMessage} {...props} isSecondaryTable>
+      <BasicTableBuilder emptyMessage={emptyMessage} {...props} isEmbeddedTable>
         {columns.map((column, index) => (
           <TableBuilderColumn<BasicTableRow>
             key={column.field}

--- a/src/components/basic-table/SecondaryBasicTable.tsx
+++ b/src/components/basic-table/SecondaryBasicTable.tsx
@@ -5,19 +5,20 @@ import { renderCell, BasicTableBuilder, BasicTableHeadCell } from './components'
 import { useBasicTableStyles } from './hooks';
 
 export const SecondaryBasicTable = ({ columns, emptyMessage, ...props }: BasicTableProps) => {
-  const { tableBodyCellStyles, tableHeadCellStyles } = useBasicTableStyles();
+  const { tableBodyCellStyles, tableHeadCellStyles, getSidePadding } = useBasicTableStyles();
 
   return (
     <>
       <BasicTableBuilder emptyMessage={emptyMessage} {...props} isSecondaryTable>
-        {columns.map((column) => (
+        {columns.map((column, index) => (
           <TableBuilderColumn<BasicTableRow>
             key={column.field}
             header={column.label}
             overrides={{
               TableHeadCell: {
                 style: {
-                  ...{ ...tableHeadCellStyles },
+                  ...tableHeadCellStyles,
+                  ...getSidePadding(index, columns.length),
                   width: column.width ?? 'auto',
                 },
                 component: ({ $style, children }) => (
@@ -29,6 +30,7 @@ export const SecondaryBasicTable = ({ columns, emptyMessage, ...props }: BasicTa
               TableBodyCell: {
                 style: {
                   ...tableBodyCellStyles,
+                  ...getSidePadding(index, columns.length),
                   width: column.width ?? 'auto',
                 },
               },

--- a/src/components/basic-table/SecondaryBasicTable.tsx
+++ b/src/components/basic-table/SecondaryBasicTable.tsx
@@ -4,12 +4,12 @@ import { TableBuilderColumn } from 'baseui/table-semantic';
 import { renderCell, BasicTableBuilder, BasicTableHeadCell } from './components';
 import { useBasicTableStyles } from './hooks';
 
-export const BasicTable = ({ columns, emptyMessage, ...props }: BasicTableProps) => {
+export const SecondaryBasicTable = ({ columns, emptyMessage, ...props }: BasicTableProps) => {
   const { tableBodyCellStyles, tableHeadCellStyles } = useBasicTableStyles();
 
   return (
     <>
-      <BasicTableBuilder emptyMessage={emptyMessage} {...props}>
+      <BasicTableBuilder emptyMessage={emptyMessage} {...props} isSecondaryTable>
         {columns.map((column) => (
           <TableBuilderColumn<BasicTableRow>
             key={column.field}
@@ -17,7 +17,7 @@ export const BasicTable = ({ columns, emptyMessage, ...props }: BasicTableProps)
             overrides={{
               TableHeadCell: {
                 style: {
-                  ...tableHeadCellStyles,
+                  ...{ ...tableHeadCellStyles },
                   width: column.width ?? 'auto',
                 },
                 component: ({ $style, children }) => (

--- a/src/components/basic-table/SecondaryBasicTable.tsx
+++ b/src/components/basic-table/SecondaryBasicTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { BasicTableProps, BasicTableRow, BasicTableColumnType } from './types';
 import { TableBuilderColumn } from 'baseui/table-semantic';
+import { BasicTableProps, BasicTableRow, BasicTableColumnType } from './types';
 import { renderCell, BasicTableBuilder, BasicTableHeadCell } from './components';
 import { useBasicTableStyles } from './hooks';
 

--- a/src/components/basic-table/components/basic-table-builder/BasicTableBuilder.tsx
+++ b/src/components/basic-table/components/basic-table-builder/BasicTableBuilder.tsx
@@ -11,7 +11,7 @@ export const BasicTableBuilder = ({ isSecondaryTable, children, emptyMessage, ..
   const {
     theme: {
       current: {
-        sizing: { scale1000, scale800 },
+        sizing: { scale800 },
         colors: { primaryB },
         customColors: { light2, light6 },
         borders: { radius200, border100 },
@@ -40,7 +40,7 @@ export const BasicTableBuilder = ({ isSecondaryTable, children, emptyMessage, ..
   const tableEmptyMessageStyles = {
     height: TABLE_ROW_HEIGHT,
     ...ParagraphSmall,
-    ...padding('0px', scale800, '0px', scale800),
+    ...padding('0', scale800),
   };
 
   return (
@@ -54,7 +54,7 @@ export const BasicTableBuilder = ({ isSecondaryTable, children, emptyMessage, ..
         },
         TableHeadRow: {
           style: {
-            height: scale1000,
+            height: TABLE_ROW_HEIGHT,
           },
         },
         TableBodyRow: {

--- a/src/components/basic-table/components/basic-table-builder/BasicTableBuilder.tsx
+++ b/src/components/basic-table/components/basic-table-builder/BasicTableBuilder.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { useTheme } from 'providers';
+import { TableBuilder, StyledTableEmptyMessage } from 'baseui/table-semantic';
+import { border, padding, borderBottom, borderTop } from '../../../../utils';
+import { TABLE_ROW_HEIGHT } from '../../../../models';
+import { EmptyMessage } from '../empty-message';
+import { BasicTableBuilderProps } from './types';
+import { useBasicTableStyles } from '../../hooks';
+
+export const BasicTableBuilder = ({ isSecondaryTable, children, emptyMessage, ...props }: BasicTableBuilderProps) => {
+  const {
+    theme: {
+      current: {
+        sizing: { scale1000, scale800 },
+        colors: { primaryB },
+        customColors: { light2, light6 },
+        borders: { radius200, border100 },
+        typography: { ParagraphSmall },
+      },
+    },
+  } = useTheme();
+
+  const { tableBodyCellStyles, tableHeadCellStyles } = useBasicTableStyles();
+
+  const getBorder = () => {
+    if (isSecondaryTable) {
+      return {
+        ...borderBottom({ ...border100, borderColor: light6 }),
+        ...borderTop({ ...border100, borderColor: light6 }),
+      };
+    }
+    return border({ ...border100, borderColor: light2 });
+  };
+
+  const tableRootStyles = {
+    ...(!isSecondaryTable ? { borderRadius: radius200 } : {}),
+    ...getBorder(),
+  };
+
+  const tableEmptyMessageStyles = {
+    height: TABLE_ROW_HEIGHT,
+    ...ParagraphSmall,
+    ...padding('0px', scale800, '0px', scale800),
+  };
+
+  return (
+    <TableBuilder
+      overrides={{
+        Root: {
+          style: tableRootStyles,
+        },
+        TableHeadCell: {
+          style: tableHeadCellStyles,
+        },
+        TableHeadRow: {
+          style: {
+            height: scale1000,
+          },
+        },
+        TableBodyRow: {
+          style: {
+            height: TABLE_ROW_HEIGHT,
+            ':hover': {
+              backgroundColor: primaryB,
+            },
+          },
+        },
+        TableBodyCell: {
+          style: tableBodyCellStyles,
+        },
+        TableEmptyMessage: {
+          style: tableEmptyMessageStyles,
+          component: ({ children, $style }) => (
+            <StyledTableEmptyMessage style={$style}>{children}</StyledTableEmptyMessage>
+          ),
+        },
+      }}
+      {...(emptyMessage ? { emptyMessage: <EmptyMessage message={emptyMessage} /> } : {})}
+      {...props}
+    >
+      {children}
+    </TableBuilder>
+  );
+};

--- a/src/components/basic-table/components/basic-table-builder/BasicTableBuilder.tsx
+++ b/src/components/basic-table/components/basic-table-builder/BasicTableBuilder.tsx
@@ -7,7 +7,7 @@ import { EmptyMessage } from '../empty-message';
 import { BasicTableBuilderProps } from './types';
 import { useBasicTableStyles } from '../../hooks';
 
-export const BasicTableBuilder = ({ isSecondaryTable, children, emptyMessage, ...props }: BasicTableBuilderProps) => {
+export const BasicTableBuilder = ({ isEmbeddedTable, children, emptyMessage, ...props }: BasicTableBuilderProps) => {
   const {
     theme: {
       current: {
@@ -23,7 +23,7 @@ export const BasicTableBuilder = ({ isSecondaryTable, children, emptyMessage, ..
   const { tableBodyCellStyles, tableHeadCellStyles } = useBasicTableStyles();
 
   const getBorder = () => {
-    if (isSecondaryTable) {
+    if (isEmbeddedTable) {
       return {
         ...borderBottom({ ...border100, borderColor: light6 }),
         ...borderTop({ ...border100, borderColor: light6 }),
@@ -33,7 +33,7 @@ export const BasicTableBuilder = ({ isSecondaryTable, children, emptyMessage, ..
   };
 
   const tableRootStyles = {
-    ...(!isSecondaryTable ? { borderRadius: radius200 } : {}),
+    ...(!isEmbeddedTable ? { borderRadius: radius200 } : {}),
     ...getBorder(),
   };
 

--- a/src/components/basic-table/components/basic-table-builder/BasicTableBuilder.tsx
+++ b/src/components/basic-table/components/basic-table-builder/BasicTableBuilder.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { useTheme } from 'providers';
 import { TableBuilder, StyledTableEmptyMessage } from 'baseui/table-semantic';
+import { useTheme } from '../../../../providers';
 import { border, padding, borderBottom, borderTop } from '../../../../utils';
 import { TABLE_ROW_HEIGHT } from '../../../../models';
 import { EmptyMessage } from '../empty-message';

--- a/src/components/basic-table/components/basic-table-builder/index.ts
+++ b/src/components/basic-table/components/basic-table-builder/index.ts
@@ -1,0 +1,1 @@
+export * from './BasicTableBuilder';

--- a/src/components/basic-table/components/basic-table-builder/types.ts
+++ b/src/components/basic-table/components/basic-table-builder/types.ts
@@ -1,0 +1,5 @@
+export interface BasicTableBuilderProps {
+  emptyMessage?: string;
+  isSecondaryTable?: boolean;
+  children: React.ReactElement[];
+}

--- a/src/components/basic-table/components/basic-table-builder/types.ts
+++ b/src/components/basic-table/components/basic-table-builder/types.ts
@@ -1,5 +1,5 @@
 export interface BasicTableBuilderProps {
   emptyMessage?: string;
-  isSecondaryTable?: boolean;
+  isEmbeddedTable?: boolean;
   children: React.ReactElement[];
 }

--- a/src/components/basic-table/components/basic-table-head-cell/BasicTableHeadCell.tsx
+++ b/src/components/basic-table/components/basic-table-head-cell/BasicTableHeadCell.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { StyledTableHeadCell } from 'baseui/table-semantic';
+import { FlexItem } from '../../../flex-item';
+import { BasicTableHeadCellProps } from './types';
+
+export const BasicTableHeadCell = ({ style, children, alignEnd }: BasicTableHeadCellProps) => {
+  return (
+    <StyledTableHeadCell style={style}>
+      <FlexItem justifyContent={alignEnd ? 'flex-end' : 'flex-start'}>{children}</FlexItem>
+    </StyledTableHeadCell>
+  );
+};

--- a/src/components/basic-table/components/basic-table-head-cell/index.ts
+++ b/src/components/basic-table/components/basic-table-head-cell/index.ts
@@ -1,0 +1,1 @@
+export * from './BasicTableHeadCell';

--- a/src/components/basic-table/components/basic-table-head-cell/types.ts
+++ b/src/components/basic-table/components/basic-table-head-cell/types.ts
@@ -1,0 +1,5 @@
+export interface BasicTableHeadCellProps {
+  style: { [key: string]: string };
+  children: React.ReactNode;
+  alignEnd?: boolean;
+}

--- a/src/components/basic-table/components/cell/Cell.tsx
+++ b/src/components/basic-table/components/cell/Cell.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { BasicTableColumn, BasicTableColumnType, BasicTableRow } from './types';
-import { ParagraphSmall } from '../typography';
-import { FlexItem } from '../flex-item';
-import { Align } from '../input/types';
+import { BasicTableColumn, BasicTableColumnType, BasicTableRow } from '../../types';
+import { ParagraphSmall } from '../../../typography';
+import { FlexItem } from '../../../flex-item';
+import { Align } from '../../../input/types';
 
 const CellWrapper = ({ children, alignRight }: { children: React.ReactElement; alignRight?: boolean }) => (
   <FlexItem height="100%" justifyContent={alignRight ? 'flex-end' : 'flex-start'} alignItems="center">
@@ -13,6 +13,7 @@ const CellWrapper = ({ children, alignRight }: { children: React.ReactElement; a
 export const renderCell = (row: BasicTableRow, column: BasicTableColumn) => {
   const { type, field } = column;
   const value = row[field];
+  console.log('8989898::', row, column);
 
   const map = {
     [BasicTableColumnType.Text]: () => (

--- a/src/components/basic-table/components/cell/Cell.tsx
+++ b/src/components/basic-table/components/cell/Cell.tsx
@@ -13,7 +13,6 @@ const CellWrapper = ({ children, alignRight }: { children: React.ReactElement; a
 export const renderCell = (row: BasicTableRow, column: BasicTableColumn) => {
   const { type, field } = column;
   const value = row[field];
-  console.log('8989898::', row, column);
 
   const map = {
     [BasicTableColumnType.Text]: () => (

--- a/src/components/basic-table/components/cell/index.ts
+++ b/src/components/basic-table/components/cell/index.ts
@@ -1,0 +1,1 @@
+export * from './Cell';

--- a/src/components/basic-table/components/empty-message/EmptyMessage.tsx
+++ b/src/components/basic-table/components/empty-message/EmptyMessage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FlexItem } from '../flex-item';
+import { FlexItem } from '../../../flex-item';
 
 export const EmptyMessage = ({ message }: { message: string }) => {
   return (

--- a/src/components/basic-table/components/empty-message/index.ts
+++ b/src/components/basic-table/components/empty-message/index.ts
@@ -1,0 +1,1 @@
+export * from './EmptyMessage';

--- a/src/components/basic-table/components/index.ts
+++ b/src/components/basic-table/components/index.ts
@@ -1,0 +1,4 @@
+export * from './empty-message';
+export * from './basic-table-builder';
+export * from './cell';
+export * from './basic-table-head-cell';

--- a/src/components/basic-table/hooks/index.ts
+++ b/src/components/basic-table/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-basic-table-styles';

--- a/src/components/basic-table/hooks/use-basic-table-styles/index.ts
+++ b/src/components/basic-table/hooks/use-basic-table-styles/index.ts
@@ -1,0 +1,1 @@
+export * from './useBasicTableStyles';

--- a/src/components/basic-table/hooks/use-basic-table-styles/useBasicTableStyles.ts
+++ b/src/components/basic-table/hooks/use-basic-table-styles/useBasicTableStyles.ts
@@ -1,6 +1,6 @@
-import { useTheme } from 'providers';
+import { useTheme } from '../../../../providers';
 import { padding } from '../../../../utils';
-import { TABLE_ROW_HEIGHT } from 'models';
+import { TABLE_ROW_HEIGHT } from '../../../../models';
 
 export const useBasicTableStyles = () => {
   const {

--- a/src/components/basic-table/hooks/use-basic-table-styles/useBasicTableStyles.ts
+++ b/src/components/basic-table/hooks/use-basic-table-styles/useBasicTableStyles.ts
@@ -1,0 +1,33 @@
+import { useTheme } from 'providers';
+import { padding } from '../../../../utils';
+import { TABLE_ROW_HEIGHT } from 'models';
+
+export const useBasicTableStyles = () => {
+  const {
+    theme: {
+      current: {
+        sizing: { scale800 },
+        customColors: { light7, light6, dark3 },
+        typography: { LabelSmall },
+      },
+    },
+  } = useTheme();
+
+  const tableHeadCellStyles = {
+    backgroundColor: light7,
+    color: dark3,
+    ...padding('0', scale800),
+    ...LabelSmall,
+    height: TABLE_ROW_HEIGHT,
+    borderBottomColor: light6,
+  };
+
+  const tableBodyCellStyles = {
+    ...padding('0', scale800),
+    height: TABLE_ROW_HEIGHT,
+    verticalAlign: 'middle',
+    borderBottomColor: light6,
+  };
+
+  return { tableBodyCellStyles, tableHeadCellStyles };
+};

--- a/src/components/basic-table/hooks/use-basic-table-styles/useBasicTableStyles.ts
+++ b/src/components/basic-table/hooks/use-basic-table-styles/useBasicTableStyles.ts
@@ -6,7 +6,7 @@ export const useBasicTableStyles = () => {
   const {
     theme: {
       current: {
-        sizing: { scale800 },
+        sizing: { scale800, scale600 },
         customColors: { light7, light6, dark3 },
         typography: { LabelSmall },
       },
@@ -16,18 +16,27 @@ export const useBasicTableStyles = () => {
   const tableHeadCellStyles = {
     backgroundColor: light7,
     color: dark3,
-    ...padding('0', scale800),
+    ...padding('0', scale600),
     ...LabelSmall,
     height: TABLE_ROW_HEIGHT,
     borderBottomColor: light6,
   };
 
   const tableBodyCellStyles = {
-    ...padding('0', scale800),
+    ...padding('0', scale600),
     height: TABLE_ROW_HEIGHT,
     verticalAlign: 'middle',
     borderBottomColor: light6,
   };
 
-  return { tableBodyCellStyles, tableHeadCellStyles };
+  const getSidePadding = (index: number, numberOfColumns: number) => {
+    if (index === 0) {
+      return { paddingLeft: scale800 };
+    } else if (index + 1 === numberOfColumns) {
+      return { paddingRight: scale800 };
+    }
+    return {};
+  };
+
+  return { tableBodyCellStyles, tableHeadCellStyles, getSidePadding };
 };

--- a/src/components/basic-table/index.ts
+++ b/src/components/basic-table/index.ts
@@ -1,3 +1,3 @@
 export * from './BasicTable';
-export * from './Cell';
+export * from './SecondaryBasicTable';
 export * from './types';

--- a/src/components/basic-table/index.ts
+++ b/src/components/basic-table/index.ts
@@ -1,3 +1,3 @@
 export * from './BasicTable';
-export * from './SecondaryBasicTable';
+export * from './EmbeddedTable';
 export * from './types';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -69,3 +69,4 @@ export * from './date-picker';
 export * from './edit-page';
 export * from './app-skeleton';
 export * from './tc-form-row';
+export * from './widget-container';

--- a/src/components/movable-table/MovableTable.tsx
+++ b/src/components/movable-table/MovableTable.tsx
@@ -1,9 +1,9 @@
+import * as React from 'react';
+import { List, arrayMove } from 'react-movable';
 import { BasicTableRow, BasicTableColumnType } from '../basic-table';
 import { renderCell } from '../basic-table/components';
 import { useBasicTableStyles } from '../basic-table/hooks';
 import { useTheme } from '../../providers';
-import * as React from 'react';
-import { List, arrayMove } from 'react-movable';
 import { borderBottom, borderTop, padding } from '../../utils';
 import { MovableTableProps } from './types';
 
@@ -16,13 +16,16 @@ export const MovableTable = ({ columns, data, setData, entityRows }: MovableTabl
         colors: { primaryB },
         customColors: { light4, light6 },
         borders: { border300 },
-        sizing: { scale600, scale800 },
+        sizing: { scale600 },
       },
     },
   } = useTheme();
 
-  const { tableBodyCellStyles: BasicTableBodyCellStyles, tableHeadCellStyles: BasicTableHeadCellStyles } =
-    useBasicTableStyles();
+  const {
+    tableBodyCellStyles: BasicTableBodyCellStyles,
+    tableHeadCellStyles: BasicTableHeadCellStyles,
+    getSidePadding,
+  } = useBasicTableStyles();
 
   const tableHeadCellStyles = {
     ...borderBottom(border300),
@@ -52,15 +55,6 @@ export const MovableTable = ({ columns, data, setData, entityRows }: MovableTabl
     if (setData) {
       setData(newData);
     }
-  };
-
-  const getSidePadding = (index: number) => {
-    if (index === 0) {
-      return { paddingLeft: scale800 };
-    } else if (index + 1 === columns?.length) {
-      return { paddingRight: scale800 };
-    }
-    return {};
   };
 
   return (
@@ -98,7 +92,7 @@ export const MovableTable = ({ columns, data, setData, entityRows }: MovableTabl
                       ...tableHeadCellStyles,
                       width: column.width ?? 'auto',
                       textAlign: column?.type === BasicTableColumnType.Financial ? 'right' : 'left',
-                      ...getSidePadding(index),
+                      ...getSidePadding(index, columns.length),
                     }}
                   >
                     {column.label}
@@ -125,7 +119,11 @@ export const MovableTable = ({ columns, data, setData, entityRows }: MovableTabl
               {columns.map((column, index) => (
                 <td
                   key={`td-${index}`}
-                  style={{ ...tableBodyCellStyles, ...getSidePadding(index), width: column.width ?? _widths[index] }}
+                  style={{
+                    ...tableBodyCellStyles,
+                    ...getSidePadding(index, columns.length),
+                    width: column.width ?? _widths[index],
+                  }}
                 >
                   {renderCell(value as unknown as BasicTableRow, column)}
                 </td>

--- a/src/components/movable-table/MovableTable.tsx
+++ b/src/components/movable-table/MovableTable.tsx
@@ -1,9 +1,10 @@
-import { BasicTableRow, renderCell } from '../basic-table';
-import { TABLE_ROW_HEIGHT } from '../../models';
+import { BasicTableRow, BasicTableColumnType } from '../basic-table';
+import { renderCell } from '../basic-table/components';
+import { useBasicTableStyles } from '../basic-table/hooks';
 import { useTheme } from '../../providers';
 import * as React from 'react';
 import { List, arrayMove } from 'react-movable';
-import { borderBottom, padding } from '../../utils';
+import { borderBottom, borderTop } from '../../utils';
 import { MovableTableProps } from './types';
 
 export const MovableTable = ({ columns, data, setData, entityRows }: MovableTableProps) => {
@@ -12,33 +13,28 @@ export const MovableTable = ({ columns, data, setData, entityRows }: MovableTabl
   const {
     theme: {
       current: {
-        sizing: { scale600 },
         colors: { primaryB },
-        customColors: { light4, light6, light7 },
+        customColors: { light4, light6 },
         borders: { border300 },
-        typography: { ParagraphSmall },
-        customSizing: { scale1025 },
       },
     },
   } = useTheme();
 
-  const tableStyles = {
-    borderSpacing: 0,
-  };
+  const { tableBodyCellStyles: BasicTableBodyCellStyles, tableHeadCellStyles: BasicTableHeadCellStyles } =
+    useBasicTableStyles();
 
   const tableHeadCellStyles = {
-    backgroundColor: light7,
-    ...padding('0', scale600),
-    ...ParagraphSmall,
-    height: scale1025,
     ...borderBottom(border300),
-  } as React.CSSProperties;
+    ...BasicTableHeadCellStyles,
+  };
 
   const tableBodyCellStyles = {
-    ...padding('0', scale600),
-    height: TABLE_ROW_HEIGHT,
-    verticalAlign: 'middle',
     ...borderBottom(border300),
+    ...BasicTableBodyCellStyles,
+  };
+
+  const tableStyles = {
+    borderSpacing: 0,
   };
 
   const tableBodyRowStyles = {
@@ -60,6 +56,7 @@ export const MovableTable = ({ columns, data, setData, entityRows }: MovableTabl
       style={{
         display: 'flex',
         justifyContent: 'stretch',
+        ...borderTop({ ...border300, borderColor: light6 }),
       }}
     >
       <List
@@ -83,7 +80,14 @@ export const MovableTable = ({ columns, data, setData, entityRows }: MovableTabl
             <thead>
               <tr>
                 {columns.map((column, index) => (
-                  <th key={`th-${index}`} style={{ ...tableHeadCellStyles, width: column.width ?? 'auto' }}>
+                  <th
+                    key={`th-${index}`}
+                    style={{
+                      ...tableHeadCellStyles,
+                      width: column.width ?? 'auto',
+                      textAlign: column?.type === BasicTableColumnType.Financial ? 'right' : 'left',
+                    }}
+                  >
                     {column.label}
                   </th>
                 ))}

--- a/src/components/movable-table/MovableTable.tsx
+++ b/src/components/movable-table/MovableTable.tsx
@@ -4,7 +4,7 @@ import { useBasicTableStyles } from '../basic-table/hooks';
 import { useTheme } from '../../providers';
 import * as React from 'react';
 import { List, arrayMove } from 'react-movable';
-import { borderBottom, borderTop } from '../../utils';
+import { borderBottom, borderTop, padding } from '../../utils';
 import { MovableTableProps } from './types';
 
 export const MovableTable = ({ columns, data, setData, entityRows }: MovableTableProps) => {
@@ -16,6 +16,7 @@ export const MovableTable = ({ columns, data, setData, entityRows }: MovableTabl
         colors: { primaryB },
         customColors: { light4, light6 },
         borders: { border300 },
+        sizing: { scale600, scale800 },
       },
     },
   } = useTheme();
@@ -26,11 +27,13 @@ export const MovableTable = ({ columns, data, setData, entityRows }: MovableTabl
   const tableHeadCellStyles = {
     ...borderBottom(border300),
     ...BasicTableHeadCellStyles,
+    ...padding('0', scale600),
   };
 
   const tableBodyCellStyles = {
     ...borderBottom(border300),
     ...BasicTableBodyCellStyles,
+    ...padding('0', scale600),
   };
 
   const tableStyles = {
@@ -49,6 +52,15 @@ export const MovableTable = ({ columns, data, setData, entityRows }: MovableTabl
     if (setData) {
       setData(newData);
     }
+  };
+
+  const getSidePadding = (index: number) => {
+    if (index === 0) {
+      return { paddingLeft: scale800 };
+    } else if (index + 1 === columns?.length) {
+      return { paddingRight: scale800 };
+    }
+    return {};
   };
 
   return (
@@ -86,6 +98,7 @@ export const MovableTable = ({ columns, data, setData, entityRows }: MovableTabl
                       ...tableHeadCellStyles,
                       width: column.width ?? 'auto',
                       textAlign: column?.type === BasicTableColumnType.Financial ? 'right' : 'left',
+                      ...getSidePadding(index),
                     }}
                   >
                     {column.label}
@@ -110,7 +123,10 @@ export const MovableTable = ({ columns, data, setData, entityRows }: MovableTabl
               }}
             >
               {columns.map((column, index) => (
-                <td key={`td-${index}`} style={{ ...tableBodyCellStyles, width: column.width ?? _widths[index] }}>
+                <td
+                  key={`td-${index}`}
+                  style={{ ...tableBodyCellStyles, ...getSidePadding(index), width: column.width ?? _widths[index] }}
+                >
                   {renderCell(value as unknown as BasicTableRow, column)}
                 </td>
               ))}

--- a/src/components/widget-container/StyledWidgetContainer.tsx
+++ b/src/components/widget-container/StyledWidgetContainer.tsx
@@ -1,0 +1,10 @@
+import { themedStyled } from '../../theme';
+import { padding, borderBottom } from '../../utils';
+
+export const StyledWidgetBox = themedStyled('div', ({ $theme }) => ({
+  ...padding($theme.sizing.scale0, $theme.sizing.scale800),
+  ...borderBottom({ ...$theme.borders.border100, borderColor: $theme.customColors.light6 }),
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+}));

--- a/src/components/widget-container/WidgetContainer.stories.tsx
+++ b/src/components/widget-container/WidgetContainer.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { WidgetContainer as WidgetContainerComponent } from './WidgetContainer';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import { WidgetContainerProps } from './types';
+import { Button } from '../button';
+import { AddLineIcon } from '../icons';
+import { ButtonKind } from '../../models';
+import { ParagraphSmall } from 'baseui/typography';
+
+export default {
+  title: 'Components/WidgetContainer',
+  component: WidgetContainerComponent,
+} as Meta;
+
+const WidgetContainerTemplate: Story<WidgetContainerProps> = (args) => (
+  <WidgetContainerComponent {...args}>
+    <ParagraphSmall>Widget wrapper</ParagraphSmall>
+  </WidgetContainerComponent>
+);
+
+export const Default = WidgetContainerTemplate.bind({});
+Default.args = {
+  title: 'Default widget wrapper',
+};
+
+const WidgetContainerButtonTemplate: Story<WidgetContainerProps> = (args) => (
+  <WidgetContainerComponent {...args}>
+    <ParagraphSmall>Widget wrapper</ParagraphSmall>
+  </WidgetContainerComponent>
+);
+
+export const ButtonWrapper = WidgetContainerButtonTemplate.bind({});
+ButtonWrapper.args = {
+  title: 'Button widget wrapper',
+  customButton: (
+    <Button kind={ButtonKind.secondary} startEnhancer={<AddLineIcon />}>
+      New
+    </Button>
+  ),
+};

--- a/src/components/widget-container/WidgetContainer.tsx
+++ b/src/components/widget-container/WidgetContainer.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { WidgetContainerProps } from './types';
+import { WidgetContent } from './components';
+import { WidgetWrapper } from './';
+
+export const WidgetContainer = ({ title, children, height, customButton }: WidgetContainerProps) => {
+  return (
+    <WidgetWrapper title={title} customButton={customButton}>
+      <WidgetContent height={height}>{children}</WidgetContent>
+    </WidgetWrapper>
+  );
+};

--- a/src/components/widget-container/WidgetWrapper.tsx
+++ b/src/components/widget-container/WidgetWrapper.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import { Box } from '../box';
 import { Block } from '../block';
 import { ParagraphSmall } from '../typography';
-import { padding } from 'utils';
-import { useTheme } from 'providers';
+import { padding, borderBottom } from '../../utils';
+import { useTheme } from '../../providers';
 import { WidgetWrapperProps } from './types';
-import { borderBottom } from '../../utils';
 
 export const WidgetWrapper = ({ title, children, customButton }: WidgetWrapperProps) => {
   const {

--- a/src/components/widget-container/WidgetWrapper.tsx
+++ b/src/components/widget-container/WidgetWrapper.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Box } from '../box';
+import { Block } from '../block';
+import { ParagraphSmall } from '../typography';
+import { padding } from 'utils';
+import { useTheme } from 'providers';
+import { WidgetWrapperProps } from './types';
+import { borderBottom } from '../../utils';
+
+export const WidgetWrapper = ({ title, children, customButton }: WidgetWrapperProps) => {
+  const {
+    theme: {
+      current: {
+        sizing: { scale800, scale0 },
+        customColors: { dark3, light6 },
+        borders: { border100 },
+      },
+    },
+  } = useTheme();
+
+  return (
+    <Box>
+      <Block
+        {...padding(scale0, scale800)}
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+        style={{ ...borderBottom({ ...border100, borderColor: light6 }) }}
+      >
+        <ParagraphSmall color={dark3} {...padding('9px', '0px')}>
+          {title}
+        </ParagraphSmall>
+        {customButton}
+      </Block>
+      {children}
+    </Box>
+  );
+};

--- a/src/components/widget-container/WidgetWrapper.tsx
+++ b/src/components/widget-container/WidgetWrapper.tsx
@@ -1,36 +1,28 @@
 import React from 'react';
 import { Box } from '../box';
-import { Block } from '../block';
 import { ParagraphSmall } from '../typography';
-import { padding, borderBottom } from '../../utils';
+import { padding } from '../../utils';
 import { useTheme } from '../../providers';
 import { WidgetWrapperProps } from './types';
+import { StyledWidgetBox } from './StyledWidgetContainer';
 
 export const WidgetWrapper = ({ title, children, customButton }: WidgetWrapperProps) => {
   const {
     theme: {
       current: {
-        sizing: { scale800, scale0 },
-        customColors: { dark3, light6 },
-        borders: { border100 },
+        customColors: { dark3 },
       },
     },
   } = useTheme();
 
   return (
     <Box>
-      <Block
-        {...padding(scale0, scale800)}
-        display="flex"
-        justifyContent="space-between"
-        alignItems="center"
-        style={{ ...borderBottom({ ...border100, borderColor: light6 }) }}
-      >
+      <StyledWidgetBox>
         <ParagraphSmall color={dark3} {...padding('9px', '0px')}>
           {title}
         </ParagraphSmall>
         {customButton}
-      </Block>
+      </StyledWidgetBox>
       {children}
     </Box>
   );

--- a/src/components/widget-container/components/index.ts
+++ b/src/components/widget-container/components/index.ts
@@ -1,0 +1,1 @@
+export * from './widget-content';

--- a/src/components/widget-container/components/widget-content/WidgetContent.tsx
+++ b/src/components/widget-container/components/widget-content/WidgetContent.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useTheme } from 'providers';
+import { Block } from 'baseui/block';
+import { padding } from '../../../../utils';
+import { WidgetContentProps } from '../../types';
+
+export const WidgetContent = ({ children, height }: WidgetContentProps) => {
+  const {
+    theme: {
+      current: {
+        sizing: { scale800, scale600 },
+      },
+    },
+  } = useTheme();
+
+  return (
+    <Block {...padding(scale600, scale800)} height={height}>
+      {children}
+    </Block>
+  );
+};

--- a/src/components/widget-container/components/widget-content/WidgetContent.tsx
+++ b/src/components/widget-container/components/widget-content/WidgetContent.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { useTheme } from 'providers';
-import { Block } from 'baseui/block';
+import { Block } from '../../../block';
 import { padding } from '../../../../utils';
 import { WidgetContentProps } from '../../types';
+import { useTheme } from '../../../../providers';
 
 export const WidgetContent = ({ children, height }: WidgetContentProps) => {
   const {

--- a/src/components/widget-container/components/widget-content/index.ts
+++ b/src/components/widget-container/components/widget-content/index.ts
@@ -1,0 +1,1 @@
+export * from './WidgetContent';

--- a/src/components/widget-container/index.ts
+++ b/src/components/widget-container/index.ts
@@ -1,0 +1,2 @@
+export * from './WidgetContainer';
+export * from './WidgetWrapper';

--- a/src/components/widget-container/types.ts
+++ b/src/components/widget-container/types.ts
@@ -1,0 +1,19 @@
+import { ReactNode, ReactElement } from 'react';
+
+export interface WidgetContainerProps {
+  title: string;
+  children: ReactNode;
+  customButton?: ReactElement;
+  height?: string;
+}
+
+export interface WidgetWrapperProps {
+  title: string;
+  children: ReactNode;
+  customButton?: ReactElement;
+}
+
+export interface WidgetContentProps {
+  children: ReactNode;
+  height?: string;
+}


### PR DESCRIPTION
- Adds new table variant and adds some styling fixes to basic table and movable table. 
- Adds widget component 

After this is merged. The widget wrapper and the new table variant can be used together to create a component inside next and customer portals with a table inside a widget. 
Also the DashboardWidgetWrapper in next can be replaced by the tacugama component 